### PR TITLE
Display colors using -v or an integer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,12 +14,28 @@ You might have to wait a few seconds for the result to be returned.
 
     ./xterm-color-count.sh -v
 
-Print each color number in its own formatting.
+Print each color number and show what it looks like.
+
+    ./xterm-color-count.sh [number]
+
+Show all the colors, like -v, but use a given number instead of the count.
 
 Bugs
 ----
 
-This does not work with the Linux console as it does not support the OSC 4 escape sequence.
+* This does not work with the Linux console as it does not support the OSC 4 escape sequence. Instead the script falls back to `tput colors` which uses the terminfo file.
+
+Discussion
+----------
+* It is a mystery why the default terminfo for XTerm and gnome-terminal lie about how many colors they have. You can "fix" it so `tput colors` returns the proper result by using `export TERM=xterm-256color`. Some applications (such as emacs in a terminal window) will use the extra colors. For example, try,
+```
+    TERM=xterm-256color  emacs -nw -f list-colors-display -f delete-window
+```
+* A 256 color XTerm has this color mapping
+  * System colors: 0 to 15
+  * Grayscale: 232 to 255 _(note, black and white intentionally omitted)_
+  * 6x6x6 color cube: 16-231
+    _(For R,G,B between 0 and 5, `color-index = 16 + R×6×6 + G×6 + B`)_
 
 Credit
 ------

--- a/xterm-color-count.sh
+++ b/xterm-color-count.sh
@@ -1,41 +1,68 @@
 #!/usr/bin/env bash
 
+trap 'tput sgr0' exit		# Clean up even if user hits ^C
+
+function setfg () {
+    printf '\e[38;5;%dm' $1
+}
+function setbg () {
+    printf '\e[48;5;%dm' $1
+}
+function showcolors() {
+    # Given an integer, display that many colors 
+    for ((i=0; i<$1; i++))
+    do
+	printf '%4d ' $i
+	setbg $i
+	tput el
+	tput sgr0
+	echo
+    done
+    tput sgr0 el
+}
+
+
+### Main starts here
+
 # First, test if terminal supports OSC 4 at all.
 printf '\e]4;%d;?\a' 0
 read -d $'\a' -s -t 0.1 </dev/tty
 if [ -z "$REPLY" ]
 then
-    # OSC 4 not supported, so we'll fall back to terminfo
-    tput colors
-    exit 0
+    # OSC 4 not supported, so we'll fall back to terminfo 
+    max=$(tput colors)
+else
+    # OSC 4 is supported, so use it for a binary search 
+    min=0
+    max=256
+    while [[ $((min+1)) -lt $max ]]
+    do
+	i=$(( (min+max)/2 ))
+	printf '\e]4;%d;?\a' $i
+	read -d $'\a' -s -t 0.1 </dev/tty
+	if [ -z "$REPLY" ]
+	then
+            max=$i
+	else
+	    min=$i
+	fi
+    done
 fi
 
-# Binary search
-min=0
-max=256
-while [[ $((min+1)) -lt $max ]]
-do
-    i=$(( (min+max)/2 ))
-    printf '\e]4;%d;?\a' $i
-    read -d $'\a' -s -t 0.1 </dev/tty
-    if [ -z "$REPLY" ]
-    then
-        max=$i
-    else
-	min=$i
-    fi
-done
 
 # If -v is given, show all the colors
-if [ "${1-}" = -v ]
-then
-    for ((i=0; i<max; i++))
-    do
-	printf '\e[%dm' $i
-	printf $i
-	tput sgr0
-	printf '\n'
-    done
-else
-    echo "$max"
-fi
+case ${1-none} in
+    none)
+	echo $max
+	;;
+    -v)
+	showcolors $max
+	;;
+    *)
+	if [[ "$1" -gt 0 ]]; then
+	    showcolors $1
+	else
+	    echo $max
+	fi
+	;;
+esac | less --raw-control-chars --QUIT-AT-EOF --no-init


### PR DESCRIPTION
Fixed the -v code to work properly. Also, you can now specify an integer from the command line and the script will pretend that that is how many colors it counted. 

_(Note: Script is getting a little long. Perhaps the counting and color displaying code should be split into separate files?)_
